### PR TITLE
Percentages (60%\75%) in table are reversed

### DIFF
--- a/in-depth/indepth_voting.rst
+++ b/in-depth/indepth_voting.rst
@@ -79,7 +79,7 @@ Non-Protocol Consensus-Changing Proposals
 +---------------+----------------------------------------------+
 |     Quorum    | 20% of all the blocks during a voting period |
 +---------------+----------------------------------------------+
-| Approval Rate |                >= 75% in favor               |
+| Approval Rate |                >= 60% in favor               |
 +---------------+----------------------------------------------+
 |    Duration   |             5,040 blocks minimum             |
 +---------------+----------------------------------------------+
@@ -96,7 +96,7 @@ Protocol Consensus Changing Proposals
 +---------------+----------------------------------------------+
 |     Quorum    | 20% of all the blocks during a voting period |
 +---------------+----------------------------------------------+
-| Approval Rate |                >= 60% in favor               |
+| Approval Rate |                >= 75% in favor               |
 +---------------+----------------------------------------------+
 |    Duration   |             10,080 blocks minimum            |
 +---------------+----------------------------------------------+


### PR DESCRIPTION
For the "Non-Protocol Consensus-Changing Proposals", the percentages were incorrectly assigned (reversed) to the Non-Protocol Consensus-Changing Proposals and Protocol Consensus Changing Proposals.

My first time editing a github project, not sure if I am doing it correctly. 